### PR TITLE
Cleanup dependencies + support .NET 4.5, fixes #15

### DIFF
--- a/src/Ben.Demystifier/Ben.Demystifier.csproj
+++ b/src/Ben.Demystifier/Ben.Demystifier.csproj
@@ -15,21 +15,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>2.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource">
-      <Version>4.4.1</Version>
-    </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>1.5.0</Version>
     </PackageReference>
-    <PackageReference Include="System.Threading.Tasks.Extensions">
+    <PackageReference Include="System.ValueTuple">
       <Version>4.4.0</Version>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
While i like roslyn, having it as a dependency for fun is quite heavy 😄 
After removing roslyn, it complained to be unable to find `TupleElementNamesAttribute` which i could fix by adding `System.ValueTuple` as a dependency, the other two dependencies were unneeded it seems.