### PR TITLE
Added a strongly-typed property for the type to ResolvedParameter and ResolvedMethod

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -183,15 +183,18 @@ namespace System.Diagnostics
                         Prefix = "",
                         Name = "",
                         Type = TypeNameHelper.GetTypeDisplayName(mi.ReturnType, fullName: false, includeGenericParameterNames: true).ToString(),
+                        ResolvedType = mi.ReturnType,
                     };
                 }
             }
 
             if (method.IsGenericMethod)
             {
-                var genericArguments = string.Join(", ", method.GetGenericArguments()
+                var genericArguments = method.GetGenericArguments();
+                var genericArgumentsString = string.Join(", ", genericArguments
                     .Select(arg => TypeNameHelper.GetTypeDisplayName(arg, fullName: false, includeGenericParameterNames: true)));
-                methodDisplayInfo.GenericArguments += "<" + genericArguments + ">";
+                methodDisplayInfo.GenericArguments += "<" + genericArgumentsString + ">";
+                methodDisplayInfo.ResolvedGenericArguments = genericArguments;
             }
 
             // Method parameters
@@ -535,6 +538,7 @@ namespace System.Diagnostics
                     Prefix = prefix,
                     Name = parameter.Name,
                     Type = parameterTypeString,
+                    ResolvedType = parameterType,
                 };
             }
 
@@ -566,6 +570,7 @@ namespace System.Diagnostics
                 Prefix = prefix,
                 Name = parameter.Name,
                 Type = parameterTypeString,
+                ResolvedType = parameterType,
             };
         }
 
@@ -605,6 +610,7 @@ namespace System.Diagnostics
                 Prefix = prefix,
                 Name = name,
                 Type = sb.ToString(),
+                ResolvedType = parameterType,
             };
         }
 

--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic.Enumerable;
@@ -24,6 +24,8 @@ namespace System.Diagnostics
         public int? Ordinal { get; set; }
 
         public string GenericArguments { get; set; }
+
+        public Type[] ResolvedGenericArguments { get; set; }
 
         public MethodBase SubMethodBase { get; set; }
 

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Ben A Adams. All rights reserved.
+// Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Text;
@@ -10,6 +10,8 @@ namespace System.Diagnostics
         public string Name { get; set; }
 
         public string Type { get; set; }
+
+        public Type ResolvedType { get; set; }
 
         public string Prefix { get; set; }
 


### PR DESCRIPTION
This commit adds the originally-resolved `Type` class as a property of `ResolvedParameter` and `ResolvedMethod`, to allow consumers to access both the pretty-printed type name and the underlying type.