### PR TITLE
Improve lambda signature formatting

### DIFF
--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -130,7 +130,7 @@ namespace System.Diagnostics
                 builder.Append(")");
                 if (IsLambda)
                 {
-                    builder.Append("=>{}");
+                    builder.Append(" => { }");
 
                     if (Ordinal.HasValue)
                     {

--- a/test/Ben.Demystifier.Test/AggregateException.cs
+++ b/test/Ben.Demystifier.Test/AggregateException.cs
@@ -38,7 +38,7 @@ namespace Demystify
             var trace = string.Join("", stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
                 // Remove items that vary between test runners
                 .Where(s =>
-                    s != "   at Task Demystify.DynamicCompilation.DoesNotPreventStackTrace()+()=>{}" &&
+                    s != "   at Task Demystify.DynamicCompilation.DoesNotPreventStackTrace()+() => { }" &&
                     !s.Contains("System.Threading.Tasks.Task.WaitAll")
                 )
                 .Skip(1)
@@ -48,18 +48,18 @@ namespace Demystify
 
             var expected = string.Join("", new[] {
                     "   at async Task Demystify.AggregateException.Throw1()",
-                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?)=>{}",
+                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?) => { }",
                     "   --- End of inner exception stack trace ---",
                     "   at void Demystify.AggregateException.DemystifiesAggregateExceptions()",
                     "---> (Inner Exception #0) System.ArgumentException: Value does not fall within the expected range.",
                     "   at async Task Demystify.AggregateException.Throw1()",
-                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?)=>{}",
+                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?) => { }",
                     "---> (Inner Exception #1) System.NullReferenceException: Object reference not set to an instance of an object.",
                     "   at async Task Demystify.AggregateException.Throw2()",
-                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?)=>{}",
+                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?) => { }",
                     "---> (Inner Exception #2) System.InvalidOperationException: Operation is not valid due to the current state of the object.",
                     "   at async Task Demystify.AggregateException.Throw3()",
-                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?)=>{}"});
+                    "   at async void Demystify.AggregateException.DemystifiesAggregateExceptions()+(?) => { }"});
 
             Assert.Equal(expected, trace);
         }

--- a/test/Ben.Demystifier.Test/DynamicCompilation.cs
+++ b/test/Ben.Demystifier.Test/DynamicCompilation.cs
@@ -42,7 +42,7 @@ namespace Demystify
                 // Remove items that vary between test runners
                 .Where(s =>
                     s != "   at void System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, object state)" &&
-                    s != "   at Task Demystify.DynamicCompilation.DoesNotPreventStackTrace()+()=>{}"
+                    s != "   at Task Demystify.DynamicCompilation.DoesNotPreventStackTrace()+() => { }"
                 )
                 .ToArray();
 

--- a/test/Ben.Demystifier.Test/NonThrownException.cs
+++ b/test/Ben.Demystifier.Test/NonThrownException.cs
@@ -34,7 +34,7 @@ namespace Demystify
             Assert.Equal(
                 new[] {     
                     "System.Exception: Exception of type 'System.Exception' was thrown. ---> System.Exception: Exception of type 'System.Exception' was thrown.",
-                    "   at Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()+()=>{}",
+                    "   at Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()+() => { }",
                     "   at async Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()",
                     "   --- End of inner exception stack trace ---"}, 
                 trace);
@@ -57,7 +57,7 @@ namespace Demystify
             Assert.Equal(
                 new[] {
                     "System.Exception: Exception of type 'System.Exception' was thrown. ---> System.Exception: Exception of type 'System.Exception' was thrown.",
-                    "   at Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()+()=>{}",
+                    "   at Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()+() => { }",
                     "   at async Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()",
                     "   --- End of inner exception stack trace ---",
                     "   at async Task Demystify.NonThrownException.DoesNotPreventThrowStackTrace()"


### PR DESCRIPTION
Improve lambda signature formatting, like default formatting in Visual Studio.

Current formatting:
```at void n.t.m()+()=>{}```

Proposed formatting:
```at void n.t.m()+() => { }```