### PR TITLE
More robust absolute path computation for the enhanced stack traces.

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Ben A Adams. All rights reserved.
+// Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
+using System.IO;
 using System.Text;
 
 namespace System.Diagnostics
@@ -104,21 +105,9 @@ namespace System.Diagnostics
                 var filePath = frame.GetFileName();
                 if (!string.IsNullOrEmpty(filePath))
                 {
-                    try
-                    {
-                        sb.Append(" in ");
-                        var uri = new Uri(filePath);
-                        if (uri.IsFile)
-                        {
-                            sb.Append(System.IO.Path.GetFullPath(filePath));
-                        }
-                        else
-                        {
-                            sb.Append(uri);
-                        }
-                    }
-                    catch
-                    { }
+                    sb.Append(" in ");
+                    sb.Append(TryGetFullPath(filePath));
+
                 }
 
                 var lineNo = frame.GetFileLineNumber();
@@ -133,5 +122,27 @@ namespace System.Diagnostics
         EnumerableIList<EnhancedStackFrame> GetEnumerator() => EnumerableIList.Create(_frames);
         IEnumerator<EnhancedStackFrame> IEnumerable<EnhancedStackFrame>.GetEnumerator() => _frames.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => _frames.GetEnumerator();
+
+        /// <summary>
+        /// Tries to convert a given <paramref name="filePath"/> to a full path.
+        /// Returns original value if the conversion isn't possible or a given path is relative.
+        /// </summary>
+        public static string TryGetFullPath(string filePath)
+        {
+            try
+            {
+                var uri = new Uri(filePath);
+                if (uri.IsFile)
+                {
+                    return uri.AbsolutePath;
+                }
+                
+                return uri.ToString();
+            }
+            catch (ArgumentException) { }
+            catch (UriFormatException) { }
+
+            return filePath;
+        }
     }
 }

--- a/test/Ben.Demystifier.Test/EnhancedStackTraceTests.cs
+++ b/test/Ben.Demystifier.Test/EnhancedStackTraceTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace Ben.Demystifier.Test
+{
+    public class EnhancedStackTraceTests
+    {
+        [Theory]
+        [InlineData(@"file://Sources\MySolution\Foo.cs", @"/MySolution/Foo.cs")]
+        [InlineData(@"d:\Public\Src\Foo.cs", @"d:/Public/Src/Foo.cs")]
+        // To be deterministic, the C# compiler can take a /pathmap command line option.
+        // This option force the compiler to emit the same bits even when their built from the
+        // differrent locations.
+        // The binaries built with the pathmap usually don't have an absolute path,
+        // but have some prefix like \.\.
+        // This test case makes sure that EhancedStackTrace can deal with such kind of paths.
+        [InlineData(@"\.\Public\Src\Foo.cs", @"/./Public/Src/Foo.cs")]
+        public void RelativePathIsConvertedToAnAbsolutePath(string original, string expected)
+        {
+            var converted = EnhancedStackTrace.TryGetFullPath(original);
+            Assert.Equal(expected, NormalizePath(converted));
+        }
+
+        // Used in tests to avoid platform-specific issues.
+        private static string NormalizePath(string path)
+            => path.Replace("\\", "/");
+    }
+}


### PR DESCRIPTION
Fix for #61 

More details in the bug above. TLDR: the stack traces are back if you build you stuff with /pathmap.