### PR TITLE
Improve path/uri handling

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -134,7 +134,7 @@ namespace System.Diagnostics
                 var uri = new Uri(filePath);
                 if (uri.IsFile)
                 {
-                    return uri.AbsolutePath;
+                    return Uri.UnescapeDataString(uri.AbsolutePath);
                 }
                 
                 return uri.ToString();

--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -129,18 +129,10 @@ namespace System.Diagnostics
         /// </summary>
         public static string TryGetFullPath(string filePath)
         {
-            try
+            if (Uri.TryCreate(filePath, UriKind.Absolute, out var uri) && uri.IsFile)
             {
-                var uri = new Uri(filePath);
-                if (uri.IsFile)
-                {
-                    return Uri.UnescapeDataString(uri.AbsolutePath);
-                }
-                
-                return uri.ToString();
+                return Uri.UnescapeDataString(uri.AbsolutePath);
             }
-            catch (ArgumentException) { }
-            catch (UriFormatException) { }
 
             return filePath;
         }

--- a/test/Ben.Demystifier.Test/EnhancedStackTraceTests.cs
+++ b/test/Ben.Demystifier.Test/EnhancedStackTraceTests.cs
@@ -22,11 +22,17 @@ namespace Ben.Demystifier.Test
         }
 
         [Theory]
-        [InlineData(@"file://Sources\My 100%.Done+Solution\Foo`1.cs", @"/My 100%.Done+Solution/Foo`1.cs")]
-        [InlineData(@"d:\Public Files+50%.Done\Src\Foo`1.cs", @"d:/Public Files+50%.Done/Src/Foo`1.cs")]
-        public void SpecialPathCharactersAreHandledCorrectly(string original, string expected)
+        [InlineData(@"file://Sources\My 100%.Done+Solution\Foo`1.cs", @"/My 100%.Done+Solution/Foo`1.cs", false)]
+        [InlineData(@"d:\Public Files+50%.Done\Src\Foo`1.cs", @"d:/Public Files+50%.Done/Src/Foo`1.cs", false)]
+        [InlineData(@"\.\Public Files+50%.Done\Src\Foo`1.cs", @"/./Public Files+50%.Done/Src/Foo`1.cs", true)]
+        public void SpecialPathCharactersAreHandledCorrectly(string original, string expected, bool normalize)
         {
             var converted = EnhancedStackTrace.TryGetFullPath(original);
+            if (normalize)
+            {
+                converted = NormalizePath(converted);
+            }
+
             Assert.Equal(expected, converted);
         }
 

--- a/test/Ben.Demystifier.Test/EnhancedStackTraceTests.cs
+++ b/test/Ben.Demystifier.Test/EnhancedStackTraceTests.cs
@@ -21,6 +21,15 @@ namespace Ben.Demystifier.Test
             Assert.Equal(expected, NormalizePath(converted));
         }
 
+        [Theory]
+        [InlineData(@"file://Sources\My 100%.Done+Solution\Foo`1.cs", @"/My 100%.Done+Solution/Foo`1.cs")]
+        [InlineData(@"d:\Public Files+50%.Done\Src\Foo`1.cs", @"d:/Public Files+50%.Done/Src/Foo`1.cs")]
+        public void SpecialPathCharactersAreHandledCorrectly(string original, string expected)
+        {
+            var converted = EnhancedStackTrace.TryGetFullPath(original);
+            Assert.Equal(expected, converted);
+        }
+
         // Used in tests to avoid platform-specific issues.
         private static string NormalizePath(string path)
             => path.Replace("\\", "/");


### PR DESCRIPTION
It _partially_ addresses #65 (because I believe that separator normalization is actually a feature, not a bug) along with a small perf improvement that prevents throwing exceptions on non-file URIs (this is actually visible in PerfView in high-volume server scenarios).