### PR TITLE
Improve StackTraceHiddenAttribute handling

### DIFF
--- a/test/Ben.Demystifier.Benchmarks/Ben.Demystifier.Benchmarks.csproj
+++ b/test/Ben.Demystifier.Benchmarks/Ben.Demystifier.Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net462</TargetFrameworks>
     <Configuration>Release</Configuration>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/Ben.Demystifier.Test/Ben.Demystifier.Test.csproj
+++ b/test/Ben.Demystifier.Test/Ben.Demystifier.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0;net46</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Ben.Demystifier\key.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR partially addresses #71, making the exception possible only in the reflection-only assembly case ona a .NET Core 2.1+ runtime.
It also explicitly differentiates runtimes based on the presence of the `StackTraceHiddenAttribute` type and uses the runtime type to compare, when the tested member is not reflection-only.
I'm not sure if stack traces from reflection-only assemblies are really possible in a running application, but I left the fallback case using `GetCustomAttributesData` for this specific case.
I also added `netcoreapp2.1` targets to tests and benchmarks to be able to test the `StackTraceHiddenAttribute` handling explicitly since it was introduced in 2.1.
The benchmarks also show minor performance and allocation improvements, will post the details if needed.