### PR TITLE
Removed code that was heuristically unreachable.

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -749,18 +749,10 @@ namespace System.Diagnostics
             }
 
             var methods = parentType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            if (methods == null)
-            {
-                return false;
-            }
 
             foreach (var candidateMethod in methods)
             {
                 var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>();
-                if (attributes == null)
-                {
-                    continue;
-                }
 
                 foreach (var asma in attributes)
                 {


### PR DESCRIPTION
Both `type.GetMethods(...)` and `methodInfo.GetCustomAttributes<>()` return an empty array if nothing was found.