### PR TITLE
Added `params` Support for ParameterInfo + Test

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -51,7 +51,7 @@ namespace System.Diagnostics
                 {
                     var frame = stackFrames[i];
                     var method = frame.GetMethod();
-                    
+
                     // Always show last stackFrame
                     if (!ShowInStackTrace(method) && i < stackFrames.Length - 1)
                     {
@@ -511,6 +511,11 @@ namespace System.Diagnostics
 
         private static string GetPrefix(ParameterInfo parameter, Type parameterType)
         {
+            if (Attribute.IsDefined(parameter, typeof(ParamArrayAttribute), false))
+            {
+                return "params";
+            }
+
             if (parameter.IsOut)
             {
                 return "out";
@@ -625,7 +630,7 @@ namespace System.Diagnostics
         private static bool ShowInStackTrace(MethodBase method)
         {
             Debug.Assert(method != null);
-            
+
             if (StackTraceHiddenAttributeType != null)
             {
                 // Don't show any methods marked with the StackTraceHiddenAttribute
@@ -635,14 +640,14 @@ namespace System.Diagnostics
                     return false;
                 }
             }
-            
+
             var type = method.DeclaringType;
-            
+
             if (type == null)
             {
                 return true;
             }
-            
+
             if (type == typeof(Task<>) && method.Name == "InnerInvoke")
             {
                 return false;

--- a/test/Ben.Demystifier.Test/ParameterParamTests.cs
+++ b/test/Ben.Demystifier.Test/ParameterParamTests.cs
@@ -1,0 +1,40 @@
+namespace Ben.Demystifier.Test
+{
+    using System;
+    using System.Diagnostics;
+    using Xunit;
+
+    public class ParameterParamTests
+    {
+        [Fact]
+        public void DemistifiesMethodWithParams()
+        {
+            Exception dex = null;
+            try
+            {
+                MethodWithParams(1, 2, 3);
+            }
+            catch (Exception e)
+            {
+                dex = e.Demystify();
+            }
+
+            // Assert
+            var stackTrace = dex.ToString();
+            stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
+            var trace = string.Join(string.Empty, stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
+
+            var expected = string.Join(string.Empty, new[] {
+                "System.ArgumentException: Value does not fall within the expected range.",
+                "   at bool Ben.Demystifier.Test.ParameterParamTests.MethodWithParams(params int[] numbers)",
+                "   at void Ben.Demystifier.Test.ParameterParamTests.DemistifiesMethodWithParams()"});
+
+            Assert.Equal(expected, trace);
+        }
+
+        private bool MethodWithParams(params int[] numbers)
+        {
+            throw new ArgumentException();
+        }
+    }
+}


### PR DESCRIPTION
This allows a more detailed description of the used method.

Bonus: Whitespaces removed.