### PR TITLE
Simplified GetPrefix `in` detection

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -509,27 +509,20 @@ namespace System.Diagnostics
             return -1;
         }
 
-        private static string GetPrefix(ParameterInfo parameter, Type parameterType)
+        private static string GetPrefix(ParameterInfo parameter)
         {
             if (parameter.IsOut)
             {
                 return "out";
             }
 
-            if (parameterType != null && parameterType.IsByRef)
+            if (parameter.IsIn)
             {
-                var attribs = parameter.GetCustomAttributes(inherit: false);
-                if (attribs?.Length > 0)
-                {
-                    foreach (var attrib in attribs)
-                    {
-                        if (attrib is Attribute att && att.GetType().IsReadOnlyAttribute())
-                        {
-                            return "in";
-                        }
-                    }
-                }
+                return "in";
+            }
 
+            if (parameter.ParameterType.IsByRef)
+            {
                 return "ref";
             }
 
@@ -538,18 +531,8 @@ namespace System.Diagnostics
 
         private static ResolvedParameter GetParameter(ParameterInfo parameter)
         {
+            var prefix = GetPrefix(parameter);
             var parameterType = parameter.ParameterType;
-            var prefix = GetPrefix(parameter, parameterType);
-
-            if (parameterType == null)
-            {
-                return new ResolvedParameter
-                {
-                    Prefix = prefix,
-                    Name = parameter.Name,
-                    ResolvedType = parameterType,
-                };
-            }
 
             if (parameterType.IsGenericType)
             {
@@ -625,7 +608,7 @@ namespace System.Diagnostics
         private static bool ShowInStackTrace(MethodBase method)
         {
             Debug.Assert(method != null);
-            
+
             if (StackTraceHiddenAttributeType != null)
             {
                 // Don't show any methods marked with the StackTraceHiddenAttribute

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -15,14 +15,6 @@ namespace System.Diagnostics.Internal
         private static PropertyInfo tranformerNamesLazyPropertyInfo;
 
         /// <summary>
-        /// Returns true if <paramref name="type"/> is <code>System.Runtime.CompilerServices.IsReadOnlyAttribute</code>.
-        /// </summary>
-        public static bool IsReadOnlyAttribute(this Type type)
-        {
-            return type.Namespace == "System.Runtime.CompilerServices" && type.Name == "IsReadOnlyAttribute";
-        }
-
-        /// <summary>
         /// Returns true if the <paramref name="type"/> is a value tuple type.
         /// </summary>
         public static bool IsValueTuple(this Type type)


### PR DESCRIPTION
This significantly reduces the reflection footprint for determining the `in` keyword.