### PR TITLE
Fixed async lambdas #72

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -116,10 +116,10 @@ namespace System.Diagnostics
             var subMethodName = method.Name;
             var methodName = method.Name;
 
-            if (type != null && type.IsDefined(typeof(CompilerGeneratedAttribute)) &&
-                (typeof(IAsyncStateMachine).IsAssignableFrom(type) || typeof(IEnumerator).IsAssignableFrom(type)))
+            var isAsyncStateMachine = typeof(IAsyncStateMachine).IsAssignableFrom(type);
+            if (isAsyncStateMachine || typeof(IEnumerator).IsAssignableFrom(type))
             {
-                methodDisplayInfo.IsAsync = typeof(IAsyncStateMachine).IsAssignableFrom(type);
+                methodDisplayInfo.IsAsync = isAsyncStateMachine;
 
                 // Convert StateMachine methods to correct overload +MoveNext()
                 if (!TryResolveStateMachineMethod(ref method, out type))

--- a/test/Ben.Demystifier.Test/MethodTests.cs
+++ b/test/Ben.Demystifier.Test/MethodTests.cs
@@ -86,7 +86,6 @@ namespace Ben.Demystifier.Test
             Assert.Equal(expected, trace);
         }
 
-
         [Fact]
         public void DemistifiesMethodWithAsyncLambda()
         {
@@ -120,7 +119,7 @@ namespace Ben.Demystifier.Test
 
         private void MethodWithLambda()
         {
-            Action action = () => throw new ArgumentException();
+            Func<bool> action = () => throw new ArgumentException();
             action();
         }
 

--- a/test/Ben.Demystifier.Test/MethodTests.cs
+++ b/test/Ben.Demystifier.Test/MethodTests.cs
@@ -2,6 +2,7 @@ namespace Ben.Demystifier.Test
 {
     using System;
     using System.Diagnostics;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class MethodTests
@@ -24,14 +25,14 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             var trace = string.Join(string.Empty, stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
 
-            var expected = string.Join(string.Empty, new[] {
+            var expected = string.Join(string.Empty,
                 "System.ArgumentException: Value does not fall within the expected range.",
                 "   at bool Ben.Demystifier.Test.MethodTests.MethodWithNullableInt(int? number)",
-                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithNullableInt()"});
+                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithNullableInt()");
 
             Assert.Equal(expected, trace);
         }
-        
+
         [Fact]
         public void DemistifiesMethodWithDynamic()
         {
@@ -50,10 +51,65 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             var trace = string.Join(string.Empty, stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
 
-            var expected = string.Join(string.Empty, new[] {
+            var expected = string.Join(string.Empty,
                 "System.ArgumentException: Value does not fall within the expected range.",
                 "   at bool Ben.Demystifier.Test.MethodTests.MethodWithDynamic(dynamic value)",
-                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithDynamic()"});
+                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithDynamic()");
+
+            Assert.Equal(expected, trace);
+        }
+
+        [Fact]
+        public void DemistifiesMethodWithLambda()
+        {
+            Exception dex = null;
+            try
+            {
+                MethodWithLambda();
+            }
+            catch (Exception e)
+            {
+                dex = e.Demystify();
+            }
+
+            // Assert
+            var stackTrace = dex.ToString();
+            stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
+            var trace = string.Join(string.Empty, stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
+
+            var expected = string.Join(string.Empty,
+                "System.ArgumentException: Value does not fall within the expected range.",
+                "   at void Ben.Demystifier.Test.MethodTests.MethodWithLambda()+() => { }",
+                "   at void Ben.Demystifier.Test.MethodTests.MethodWithLambda()",
+                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithLambda()");
+
+            Assert.Equal(expected, trace);
+        }
+
+
+        [Fact]
+        public void DemistifiesMethodWithAsyncLambda()
+        {
+            Exception dex = null;
+            try
+            {
+                MethodWithAsyncLambda();
+            }
+            catch (Exception e)
+            {
+                dex = e.Demystify();
+            }
+
+            // Assert
+            var stackTrace = dex.ToString();
+            stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
+            var trace = string.Join(string.Empty, stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
+
+            var expected = string.Join(string.Empty,
+                "System.ArgumentException: Value does not fall within the expected range.",
+                "   at async void Ben.Demystifier.Test.MethodTests.MethodWithAsyncLambda()+(?) => { }",
+                "   at void Ben.Demystifier.Test.MethodTests.MethodWithAsyncLambda()",
+                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithAsyncLambda()");
 
             Assert.Equal(expected, trace);
         }
@@ -61,5 +117,17 @@ namespace Ben.Demystifier.Test
         private bool MethodWithNullableInt(int? number) => throw new ArgumentException();
 
         private bool MethodWithDynamic(dynamic value) => throw new ArgumentException();
+
+        private void MethodWithLambda()
+        {
+            Action action = () => throw new ArgumentException();
+            action();
+        }
+
+        private void MethodWithAsyncLambda()
+        {
+            Func<Task> action = async () => throw new ArgumentException();
+            action().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
     }
 }


### PR DESCRIPTION
The `type.IsDefined(typeof(CompilerGeneratedAttribute))` check removed, since it led to the exclusion of `async lambdas`.

Resolves https://github.com/benaadams/Ben.Demystifier/issues/72