### PR TITLE
Allow external calling of ResolvedMethod/ResolvedParameter.Append() changing from private->public

### DIFF
--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -37,7 +37,7 @@ namespace System.Diagnostics
 
         public override string ToString() => Append(new StringBuilder()).ToString();
 
-        internal StringBuilder Append(StringBuilder builder)
+        public StringBuilder Append(StringBuilder builder)
         {
             if (IsAsync)
             {

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics
 
         public override string ToString() => Append(new StringBuilder()).ToString();
 
-        internal StringBuilder Append(StringBuilder sb)
+        public StringBuilder Append(StringBuilder sb)
         {
             if (!string.IsNullOrEmpty(Prefix))
             {


### PR DESCRIPTION
While ToString could be used if using in an external library that is building a stack trace calling the string builder method is more performant.    I mainly have updated:
https://github.com/mitchcapper/ProductionStackTrace
to use it, but would like to change the line:
https://github.com/mitchcapper/ProductionStackTrace/blob/8d5e4aacf84205755baa49fea7ddb2f83e3be967/ProductionStackTrace/ExceptionReporting.cs#L123


