### PR TITLE
Deterministic builds - GH actions ContinuousIntegrationBuild

### DIFF
--- a/directory.build.props
+++ b/directory.build.props
@@ -1,4 +1,5 @@
 ﻿<Project>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
SourceLink is already in, but not marking the build as CI (now GH actions is in place, it's just):

https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/#deterministic-builds