### PR TITLE
deterministic builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0' and !$(TargetFramework.StartsWith('netcoreapp2')) and !$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);HAS_ASYNC_ENUMERATOR</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
SourceLink is already in, but not marking the build as CI (now GH actions is in place, it's just):

https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/#deterministic-builds