### PR TITLE
Enabled Nullable Reference Types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0' and !$(TargetFramework.StartsWith('netcoreapp2')) and !$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);HAS_ASYNC_ENUMERATOR</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0' and !$(TargetFramework.StartsWith('netcoreapp2')) and !$(TargetFramework.StartsWith('net4'))">
     <DefineConstants>$(DefineConstants);HAS_ASYNC_ENUMERATOR</DefineConstants>

--- a/src/Ben.Demystifier/Ben.Demystifier.csproj
+++ b/src/Ben.Demystifier/Ben.Demystifier.csproj
@@ -12,6 +12,7 @@
     <IncludeSource>true</IncludeSource>
     <DebugType>embedded</DebugType>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -7,15 +7,15 @@ namespace System.Diagnostics
 {
     public class EnhancedStackFrame : StackFrame
     {
-        private string _fileName;
-        private int _lineNumber;
-        private int _colNumber;
+        private readonly string? _fileName;
+        private readonly int _lineNumber;
+        private readonly int _colNumber;
 
         public StackFrame StackFrame { get; }
 
         public ResolvedMethod MethodInfo { get; }
 
-        internal EnhancedStackFrame(StackFrame stackFrame, ResolvedMethod methodInfo, string fileName, int lineNumber, int colNumber)
+        internal EnhancedStackFrame(StackFrame stackFrame, ResolvedMethod methodInfo, string? fileName, int lineNumber, int colNumber)
             : base(fileName, lineNumber, colNumber)
         {
             StackFrame = stackFrame;
@@ -45,7 +45,7 @@ namespace System.Diagnostics
         ///     This information is typically extracted from the debugging symbols for the executable.
         /// </summary>
         /// <returns>The file name, or null if the file name cannot be determined.</returns>
-        public override string GetFileName() => _fileName;
+        public override string? GetFileName() => _fileName;
 
         /// <summary>
         ///    Gets the offset from the start of the Microsoft intermediate language (MSIL)

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics
             _colNumber = colNumber;
         }
 
-        internal bool IsEquivalent(ResolvedMethod methodInfo, string fileName, int lineNumber, int colNumber)
+        internal bool IsEquivalent(ResolvedMethod methodInfo, string? fileName, int lineNumber, int colNumber)
         {
             return _lineNumber == lineNumber &&
                 _colNumber == colNumber &&

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -44,8 +44,8 @@ namespace System.Diagnostics
                 return frames;
             }
 
-            EnhancedStackFrame lastFrame = null;
-            PortablePdbReader portablePdbReader = null;
+            EnhancedStackFrame? lastFrame = null;
+            PortablePdbReader? portablePdbReader = null;
             try
             {
                 for (var i = 0; i < stackFrames.Length; i++)
@@ -70,6 +70,12 @@ namespace System.Diagnostics
                         (portablePdbReader ??= new PortablePdbReader()).PopulateStackFrame(frame, method, frame.GetILOffset(), out fileName, out row, out column);
                     }
 
+                    if (method is null)
+                    {
+                        // Method can't be null
+                        continue;
+                    }
+
                     var resolvedMethod = GetMethodDisplayString(method);
                     if (lastFrame?.IsEquivalent(resolvedMethod, fileName, row, column) ?? false)
                     {
@@ -85,11 +91,7 @@ namespace System.Diagnostics
             }
             finally
             {
-                if (portablePdbReader is not null)
-                {
-                    portablePdbReader.Dispose();
-                }
-
+                portablePdbReader?.Dispose();
             }
 
             return frames;

--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -101,12 +101,13 @@ namespace System.Diagnostics
 
                 sb.Append("   at ");
                 frame.MethodInfo.Append(sb);
-
-                var filePath = frame.GetFileName();
-                if (!string.IsNullOrEmpty(filePath))
+                
+                if (frame.GetFileName() is {} fileName
+                    // IsNullOrEmpty alone wasn't enough to disable the null warning
+                    && !string.IsNullOrEmpty(fileName))
                 {
                     sb.Append(" in ");
-                    sb.Append(TryGetFullPath(filePath));
+                    sb.Append(TryGetFullPath(fileName));
 
                 }
 

--- a/src/Ben.Demystifier/Enumerable/EnumeratorIList.cs
+++ b/src/Ben.Demystifier/Enumerable/EnumeratorIList.cs
@@ -24,7 +24,7 @@ namespace System.Collections.Generic.Enumerable
         }
 
         public void Dispose() { }
-        object IEnumerator.Current => Current;
+        object? IEnumerator.Current => Current;
         public void Reset() => _index = -1;
     }
 }

--- a/src/Ben.Demystifier/Internal/ILReader.cs
+++ b/src/Ben.Demystifier/Internal/ILReader.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics.Internal
 
         public OpCode OpCode { get; private set; }
         public int MetadataToken { get; private set; }
-        public MemberInfo Operand { get; private set; }
+        public MemberInfo? Operand { get; private set; }
 
         public bool Read(MethodBase methodInfo)
         {
@@ -38,7 +38,7 @@ namespace System.Diagnostics.Internal
                 return doubleByteOpCode[ReadByte()];
         }
 
-        MemberInfo ReadOperand(OpCode code, MethodBase methodInfo)
+        MemberInfo? ReadOperand(OpCode code, MethodBase methodInfo)
         {
             MetadataToken = 0;
             int inlineLength;
@@ -46,12 +46,12 @@ namespace System.Diagnostics.Internal
             {
                 case OperandType.InlineMethod:
                     MetadataToken = ReadInt();
-                    Type[] methodArgs = null;
+                    Type[]? methodArgs = null;
                     if (methodInfo.GetType() != typeof(ConstructorInfo) && !methodInfo.GetType().IsSubclassOf(typeof(ConstructorInfo)))
                     {
                         methodArgs = methodInfo.GetGenericArguments();
                     }
-                    Type[] typeArgs = null;
+                    Type[]? typeArgs = null;
                     if (methodInfo.DeclaringType != null)
                     {
                         typeArgs = methodInfo.DeclaringType.GetGenericArguments();

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.Internal
     /// </summary>
     public static class ReflectionHelper
     {
-        private static PropertyInfo tranformerNamesLazyPropertyInfo;
+        private static PropertyInfo? tranformerNamesLazyPropertyInfo;
 
         /// <summary>
         /// Returns true if the <paramref name="type"/> is a value tuple type.
@@ -43,15 +43,15 @@ namespace System.Diagnostics.Internal
         /// To avoid compile-time depencency hell with System.ValueTuple, this method uses reflection 
         /// instead of casting the attribute to a specific type.
         /// </remarks>
-        public static IList<string> GetTransformerNames(this Attribute attribute)
+        public static IList<string>? GetTransformerNames(this Attribute attribute)
         {
             Debug.Assert(attribute.IsTupleElementNameAttribue());
 
             var propertyInfo = GetTransformNamesPropertyInfo(attribute.GetType());
-            return (IList<string>)propertyInfo.GetValue(attribute);
+            return propertyInfo?.GetValue(attribute) as IList<string>;
         }
 
-        private static PropertyInfo GetTransformNamesPropertyInfo(Type attributeType)
+        private static PropertyInfo? GetTransformNamesPropertyInfo(Type attributeType)
         {
             return LazyInitializer.EnsureInitialized(ref tranformerNamesLazyPropertyInfo,
                 () => attributeType.GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public));

--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -9,27 +9,27 @@ namespace System.Diagnostics
 {
     public class ResolvedMethod
     {
-        public MethodBase MethodBase { get; set; }
+        public MethodBase? MethodBase { get; set; }
 
-        public Type DeclaringType { get; set; }
+        public Type? DeclaringType { get; set; }
         
         public bool IsAsync { get; set; }
 
         public bool IsLambda { get; set; }
 
-        public ResolvedParameter ReturnParameter { get; set; }
+        public ResolvedParameter? ReturnParameter { get; set; }
 
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         public int? Ordinal { get; set; }
 
-        public string GenericArguments { get; set; }
+        public string? GenericArguments { get; set; }
 
-        public Type[] ResolvedGenericArguments { get; set; }
+        public Type[]? ResolvedGenericArguments { get; set; }
 
-        public MethodBase SubMethodBase { get; set; }
+        public MethodBase? SubMethodBase { get; set; }
 
-        public string SubMethod { get; set; }
+        public string? SubMethod { get; set; }
 
         public EnumerableIList<ResolvedParameter> Parameters { get; set; }
 

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -7,12 +7,14 @@ namespace System.Diagnostics
 {
     public class ResolvedParameter
     {
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         public Type ResolvedType { get; set; }
 
-        public string Prefix { get; set; }
+        public string? Prefix { get; set; }
         public bool IsDynamicType { get; set; }
+
+        public ResolvedParameter(Type resolvedType) => ResolvedType = resolvedType;
 
         public override string ToString() => Append(new StringBuilder()).ToString();
 

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -9,24 +9,30 @@ namespace System.Diagnostics
 {
     public class ValueTupleResolvedParameter : ResolvedParameter
     {
-        public IList<string> TupleNames { get; set; }
+        public IList<string> TupleNames { get; }
+
+        public ValueTupleResolvedParameter(Type resolvedType, IList<string> tupleNames) 
+            : base(resolvedType) 
+            => TupleNames = tupleNames;
 
         protected override void AppendTypeName(StringBuilder sb)
         {
-            if (ResolvedType.IsValueTuple())
+            if (ResolvedType is not null)
             {
-                AppendValueTupleParameterName(sb, ResolvedType);
-            }
-            else
-            {
-                // Need to unwrap the first generic argument first.
-                sb.Append(TypeNameHelper.GetTypeNameForGenericType(ResolvedType));
-                sb.Append("<");
-                AppendValueTupleParameterName(sb, ResolvedType.GetGenericArguments()[0]);
-                sb.Append(">");
+                if (ResolvedType.IsValueTuple())
+                {
+                    AppendValueTupleParameterName(sb, ResolvedType);
+                }
+                else
+                {
+                    // Need to unwrap the first generic argument first.
+                    sb.Append(TypeNameHelper.GetTypeNameForGenericType(ResolvedType));
+                    sb.Append("<");
+                    AppendValueTupleParameterName(sb, ResolvedType.GetGenericArguments()[0]);
+                    sb.Append(">");
+                }
             }
         }
-
 
         private void AppendValueTupleParameterName(StringBuilder sb, Type parameterType)
         {

--- a/test/Ben.Demystifier.Test/MethodTests.cs
+++ b/test/Ben.Demystifier.Test/MethodTests.cs
@@ -125,7 +125,9 @@ namespace Ben.Demystifier.Test
 
         private void MethodWithAsyncLambda()
         {
+#pragma warning disable 1998
             Func<Task> action = async () => throw new ArgumentException();
+#pragma warning restore 1998
             action().ConfigureAwait(false).GetAwaiter().GetResult();
         }
     }


### PR DESCRIPTION
@benaadams only `Ben.Demystifier` so far. Likely enough?

If so I can move `PackageRerence` of `Nullable` to that lib instead of the parent Directory.Build.props.

I did add some small "refactoring" into this PR, if you rather those stay our, I can undo.

Another unrelated change I'm happy to undo: Tread warnings as errors.

Resolves #126