### PR TITLE
build in sentry csproj

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -74,7 +74,7 @@ namespace System.Diagnostics
         ///     Gets the method in which the frame is executing.
         /// </summary>
         /// <returns>The method in which the frame is executing.</returns>
-        public override MethodBase GetMethod() => StackFrame.GetMethod();
+        public override MethodBase? GetMethod() => StackFrame.GetMethod();
 
         /// <summary>
         ///     Gets the offset from the start of the native just-in-time (JIT)-compiled code

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -19,7 +19,7 @@ namespace System.Diagnostics
 {
     public partial class EnhancedStackTrace
     {
-        private static readonly Type StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
+        private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
 
         private static List<EnhancedStackFrame> GetFrames(Exception exception)
         {
@@ -51,6 +51,10 @@ namespace System.Diagnostics
                 for (var i = 0; i < stackFrames.Length; i++)
                 {
                     var frame = stackFrames[i];
+                    if (frame is null)
+                    {
+                        continue;
+                    }
                     var method = frame.GetMethod();
 
                     // Always show last stackFrame
@@ -167,7 +171,7 @@ namespace System.Diagnostics
                             foreach (var field in fields)
                             {
                                 var value = field.GetValue(field);
-                                if (value is Delegate d)
+                                if (value is Delegate d && d.Target is not null)
                                 {
                                     if (ReferenceEquals(d.Method, originMethod) &&
                                         d.Target.ToString() == originMethod.DeclaringType?.ToString())
@@ -359,7 +363,7 @@ namespace System.Diagnostics
             return false;
         }
 
-        private static bool TryResolveSourceMethod(IEnumerable<MethodBase> candidateMethods, GeneratedNameKind kind, string? matchHint, ref MethodBase method, ref Type type, out int? ordinal)
+        private static bool TryResolveSourceMethod(IEnumerable<MethodBase> candidateMethods, GeneratedNameKind kind, string? matchHint, ref MethodBase method, ref Type? type, out int? ordinal)
         {
             ordinal = null;
             foreach (var candidateMethod in candidateMethods)
@@ -386,6 +390,10 @@ namespace System.Diagnostics
                 try
                 {
                     var rawIl = methodBody.GetILAsByteArray();
+                    if (rawIl is null)
+                    {
+                        continue;
+                    }
                     var reader = new ILReader(rawIl);
                     while (reader.Read(candidateMethod))
                     {
@@ -434,23 +442,25 @@ namespace System.Diagnostics
 
                 ordinal = foundOrdinal;
 
-                var methods = method.DeclaringType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                var methods = method.DeclaringType?.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
 
-                var startName = method.Name.Substring(0, lamdaStart);
                 var count = 0;
-                foreach (var m in methods)
+                if (methods != null)
                 {
-                    if (m.Name.Length > lamdaStart && m.Name.StartsWith(startName))
+                    var startName = method.Name.Substring(0, lamdaStart);
+                    foreach (var m in methods)
                     {
-                        count++;
-
-                        if (count > 1)
+                        if (m.Name.Length > lamdaStart && m.Name.StartsWith(startName))
                         {
-                            break;
+                            count++;
+
+                            if (count > 1)
+                            {
+                                break;
+                            }
                         }
                     }
                 }
-
 
                 if (count <= 1)
                 {
@@ -600,7 +610,7 @@ namespace System.Diagnostics
             };
         }
 
-        private static ResolvedParameter GetValueTupleParameter(IList<string> tupleNames, string prefix, string name, Type parameterType)
+        private static ResolvedParameter GetValueTupleParameter(IList<string> tupleNames, string prefix, string? name, Type parameterType)
         {
             return new ValueTupleResolvedParameter(parameterType, tupleNames)
             {
@@ -748,7 +758,7 @@ namespace System.Diagnostics
             
             if (type.Namespace == "Ply")
             {
-                if (type.DeclaringType.Name == "TplPrimitives")
+                if (type.DeclaringType?.Name == "TplPrimitives")
                 {
                     return false;
                 }
@@ -788,7 +798,7 @@ namespace System.Diagnostics
 
         private static bool IsStackTraceHidden(MemberInfo memberInfo)
         {
-            if (!memberInfo.Module.Assembly.ReflectionOnly)
+            if (StackTraceHiddenAttributeType is not null && !memberInfo.Module.Assembly.ReflectionOnly)
             {
                 return memberInfo.GetCustomAttributes(StackTraceHiddenAttributeType, false).Length != 0;
             }
@@ -806,7 +816,7 @@ namespace System.Diagnostics
             foreach (var attribute in attributes)
             {
                 // reflection-only attribute, match on name
-                if (attribute.AttributeType.FullName == StackTraceHiddenAttributeType.FullName)
+                if (attribute.AttributeType.FullName == StackTraceHiddenAttributeType?.FullName)
                 {
                     return true;
                 }

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -34,7 +34,7 @@ namespace System.Diagnostics
             return GetFrames(stackTrace);
         }
 
-        private static List<EnhancedStackFrame> GetFrames(StackTrace stackTrace)
+        public static List<EnhancedStackFrame> GetFrames(StackTrace stackTrace)
         {
             var frames = new List<EnhancedStackFrame>();
             var stackFrames = stackTrace.GetFrames();

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -8,8 +8,7 @@ using System.Text;
 
 namespace System.Diagnostics
 {
-    /// <nodoc />
-    public static class ExceptionExtentions
+    public static class ExceptionExtensions
     {
         private static readonly FieldInfo? stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/src/Ben.Demystifier/ExceptionExtentions.cs
+++ b/src/Ben.Demystifier/ExceptionExtentions.cs
@@ -11,10 +11,10 @@ namespace System.Diagnostics
     /// <nodoc />
     public static class ExceptionExtentions
     {
-        private static readonly FieldInfo stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo? stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
 
         private static void SetStackTracesString(this Exception exception, string value)
-            => stackTraceString.SetValue(exception, value);
+            => stackTraceString?.SetValue(exception, value);
 
         /// <summary>
         /// Demystifies the given <paramref name="exception"/> and tracks the original stack traces for the whole exception tree.

--- a/src/Ben.Demystifier/Internal/ILReader.cs
+++ b/src/Ben.Demystifier/Internal/ILReader.cs
@@ -129,7 +129,7 @@ namespace System.Diagnostics.Internal
 
             for (var i = 0; i < fields.Length; i++)
             {
-                var code = (OpCode)fields[i].GetValue(null);
+                var code = (OpCode)fields[i].GetValue(null)!;
                 if (code.OpCodeType == OpCodeType.Nternal)
                     continue;
 

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -70,7 +70,7 @@ namespace System.Diagnostics.Internal
 
         private MetadataReader? GetMetadataReader(string assemblyPath)
         {
-            if (!_cache.TryGetValue(assemblyPath, out var provider))
+            if (!_cache.TryGetValue(assemblyPath, out var provider) && provider is not null)
             {
                 var pdbPath = GetPdbPath(assemblyPath);
 

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -53,7 +53,9 @@ namespace System.Diagnostics.Internal
 
         private static PropertyInfo? GetTransformNamesPropertyInfo(Type attributeType)
         {
+#pragma warning disable 8634
             return LazyInitializer.EnsureInitialized(ref tranformerNamesLazyPropertyInfo,
+#pragma warning restore 8634
                 () => attributeType.GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public));
         }
     }

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -124,7 +124,10 @@ namespace System.Diagnostics
             var innerType = type;
             while (innerType.IsArray)
             {
-                innerType = innerType.GetElementType();
+                if (innerType.GetElementType() is { } inner)
+                {
+                    innerType = inner;
+                }
             }
 
             ProcessType(builder, innerType, options);
@@ -134,21 +137,25 @@ namespace System.Diagnostics
                 builder.Append('[');
                 builder.Append(',', type.GetArrayRank() - 1);
                 builder.Append(']');
-                type = type.GetElementType();
+                if (type.GetElementType() is not { } elementType)
+                {
+                    break;
+                }
+                type = elementType;
             }
         }
 
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {
             var offset = 0;
-            if (type.IsNested)
+            if (type.IsNested && type.DeclaringType is not null)
             {
                 offset = type.DeclaringType.GetGenericArguments().Length;
             }
 
             if (options.FullName)
             {
-                if (type.IsNested)
+                if (type.IsNested && type.DeclaringType is not null)
                 {
                     ProcessGenericType(builder, type.DeclaringType, genericArguments, offset, options);
                     builder.Append('+');

--- a/test/Ben.Demystifier.Test/AggregateException.cs
+++ b/test/Ben.Demystifier.Test/AggregateException.cs
@@ -44,7 +44,7 @@ namespace Ben.Demystifier.Test
                 .ToArray())
                 // Remove Full framework back arrow
                 .Replace("<---", "");
-#if NET5_0 || NETCOREAPP3_1
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
             var expected = string.Join("", new[] {
                 " ---> System.ArgumentException: Value does not fall within the expected range.",
                 "   at async Task Ben.Demystifier.Test.AggregateException.Throw1()",

--- a/test/Ben.Demystifier.Test/MixedStack.cs
+++ b/test/Ben.Demystifier.Test/MixedStack.cs
@@ -109,7 +109,7 @@ namespace Ben.Demystifier.Test
         static Func<string, bool, (string val, bool)> s_func = (string s, bool b) => (RefMethod(s), b);
         static string s = "";
 
-        class GenericClass<T>
+        static class GenericClass<T>
         {
             [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
             public static string GenericMethod<V>(ref V value)

--- a/test/Ben.Demystifier.Test/NonThrownException.cs
+++ b/test/Ben.Demystifier.Test/NonThrownException.cs
@@ -31,7 +31,7 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             var trace = stackTrace.Split(new[]{Environment.NewLine}, StringSplitOptions.None);
 
-#if NETCOREAPP3_1 || NET5_0
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
             Assert.Equal(
                 new[] {     
                     "System.Exception: Exception of type 'System.Exception' was thrown.",
@@ -65,7 +65,7 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             trace = stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
 
-#if NETCOREAPP3_1 || NET5_0
+#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
             Assert.Equal(
                 new[] {
                     "System.Exception: Exception of type 'System.Exception' was thrown.",

--- a/test/Ben.Demystifier.Test/TypeNameTests.cs
+++ b/test/Ben.Demystifier.Test/TypeNameTests.cs
@@ -25,5 +25,5 @@ namespace Ben.Demystifier.Test
         }
     }
 
-    public class Generic<T> { public struct Nested { } }
+    public static class Generic<T> { public struct Nested { } }
 }


### PR DESCRIPTION
Changes I had to make to build and test inside the Sentry SDK.

I'm hoping to clean up the changes here and merge it back upstream, if possible.
I suspect the `strict` flag is what drove some of the changes, unsure yet since it also builds against `net5.0` here.

Sentry PR: https://github.com/getsentry/sentry-dotnet/pull/732