### PR TITLE
Add captured frames to EnhancedStackTrace

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -21,6 +21,10 @@ namespace System.Diagnostics
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
 
+        private static readonly FieldInfo? CapturedTraces = typeof(Exception).GetField("captured_traces", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo? Frames = typeof(StackTrace).GetField("frames", BindingFlags.Instance | BindingFlags.NonPublic);
+        
+        
         private static List<EnhancedStackFrame> GetFrames(Exception exception)
         {
             if (exception == null)
@@ -30,6 +34,32 @@ namespace System.Diagnostics
 
             var needFileInfo = true;
             var stackTrace = new StackTrace(exception, needFileInfo);
+
+            if (Frames != null && CapturedTraces?.GetValue(exception) is StackTrace[] captured)
+            {
+                if (captured.Length > 0)
+                {
+                    var allFrames = new List<StackFrame>();
+                    foreach (var cap in captured)
+                    {
+                        if (cap.FrameCount > 0)
+                        {
+                            for (var i = 0; i < cap.FrameCount; i++)
+                            {
+                                var frame = cap.GetFrame(i);
+                                allFrames.Add(frame);
+                            }
+                        }
+                    }
+
+                    var frames = Frames.GetValue(stackTrace);
+                    if (frames is StackFrame[] existing)
+                    {
+                        allFrames.AddRange(existing);
+                        Frames.SetValue(stackTrace, allFrames.ToArray());
+                    }
+                }
+            }
 
             return GetFrames(stackTrace);
         }


### PR DESCRIPTION
Injecting captured stackframes into EnhancedStackTrace

Example without injection in Unity context:
Before
![2021-02-25-093227](https://user-images.githubusercontent.com/5083203/109126210-4d6b5900-774d-11eb-918e-4be6c2ca9abd.png)

After
![2021-02-25-093311](https://user-images.githubusercontent.com/5083203/109126280-5bb97500-774d-11eb-9e00-e7e2b6310f51.png)

Example using sample in Unity context:
Before:
![uncaughtsample-2021-02-25-093701](https://user-images.githubusercontent.com/5083203/109126330-6aa02780-774d-11eb-8852-1c94028a644b.png)

After:
![uncaughtsample-captured-2021-02-25-093754](https://user-images.githubusercontent.com/5083203/109126338-6e33ae80-774d-11eb-92e0-34d3b163a558.png)
