### PR TITLE
Update csproj to use LicenseExpression

### DIFF
--- a/src/Ben.Demystifier/Ben.Demystifier.csproj
+++ b/src/Ben.Demystifier/Ben.Demystifier.csproj
@@ -7,7 +7,7 @@
     <Authors>Ben Adams</Authors>
     <RepositoryUrl>https://github.com/benaadams/Ben.Demystifier</RepositoryUrl>
     <PackageProjectUrl>https://github.com/benaadams/Ben.Demystifier</PackageProjectUrl>
-    <License>Apache-2.0</License>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <IncludeSource>true</IncludeSource>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
I assume this should have been `LicenseExpression`
See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file