### PR TITLE
support for .NET 6

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,6 +22,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET SDK (v6.0)
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+            dotnet-version: '6.0.100-preview.7.21379.14'
+
       - name: Get .NET information
         run: dotnet --info
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,19 +25,19 @@ jobs:
       - name: Setup .NET SDK (v2.1)
         uses: actions/setup-dotnet@v1.7.2
         with:
-            dotnet-version: '2.1.818'
+          dotnet-version: '2.1.818'
       - name: Setup .NET SDK (v3.1)
         uses: actions/setup-dotnet@v1.7.2
         with:
-            dotnet-version: '3.1.401'
+          dotnet-version: '3.1.414'
       - name: Setup .NET SDK (v5.0)
         uses: actions/setup-dotnet@v1.7.2
         with:
-            dotnet-version: '5.0.400'
+          dotnet-version: '5.0.402'
       - name: Setup .NET SDK (v6.0)
         uses: actions/setup-dotnet@v1.7.2
         with:
-            dotnet-version: '6.0.100-preview.7.21379.14'
+          dotnet-version: '6.0.100-rc.2.21505.57'
 
       - name: Get .NET information
         run: dotnet --info

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,6 +22,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET SDK (v2.1)
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+            dotnet-version: '2.1.818'
+      - name: Setup .NET SDK (v3.1)
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+            dotnet-version: '3.1.401'
+      - name: Setup .NET SDK (v5.0)
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+            dotnet-version: '5.0.400'
       - name: Setup .NET SDK (v6.0)
         uses: actions/setup-dotnet@v1.7.2
         with:

--- a/test/Ben.Demystifier.Test/AggregateException.cs
+++ b/test/Ben.Demystifier.Test/AggregateException.cs
@@ -44,7 +44,7 @@ namespace Ben.Demystifier.Test
                 .ToArray())
                 // Remove Full framework back arrow
                 .Replace("<---", "");
-#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
             var expected = string.Join("", new[] {
                 " ---> System.ArgumentException: Value does not fall within the expected range.",
                 "   at async Task Ben.Demystifier.Test.AggregateException.Throw1()",

--- a/test/Ben.Demystifier.Test/Ben.Demystifier.Test.csproj
+++ b/test/Ben.Demystifier.Test/Ben.Demystifier.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net46</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Ben.Demystifier\key.snk</AssemblyOriginatorKeyFile>

--- a/test/Ben.Demystifier.Test/NonThrownException.cs
+++ b/test/Ben.Demystifier.Test/NonThrownException.cs
@@ -31,7 +31,7 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             var trace = stackTrace.Split(new[]{Environment.NewLine}, StringSplitOptions.None);
 
-#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
             Assert.Equal(
                 new[] {     
                     "System.Exception: Exception of type 'System.Exception' was thrown.",
@@ -65,7 +65,7 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             trace = stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
 
-#if NET5_0 || NETCOREAPP3_1 || NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
             Assert.Equal(
                 new[] {
                     "System.Exception: Exception of type 'System.Exception' was thrown.",
@@ -109,7 +109,12 @@ namespace Ben.Demystifier.Test
 
             Assert.Equal(
                 new[] {
-                    "   at bool System.Threading.ThreadPoolWorkQueue.Dispatch()"},
+                    "   at bool System.Threading.ThreadPoolWorkQueue.Dispatch()",
+#if NET6_0_OR_GREATER
+                    "   at void System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart()",
+                    "   at void System.Threading.Thread.StartCallback()",
+#endif
+                },
                 trace);
         }
     }


### PR DESCRIPTION
I assume you might want to wait for GA?
But since I've been testing Sentry's .NET SDK against it, I needed to get it to build so give us a head starts here, here's a PR.

- [ ] Once GHA installs .NET 6 we can drop these explicit sdk installs from the workflow