### PR TITLE
fix null inLazyInitializer.EnsureInitialized func

### DIFF
--- a/src/Ben.Demystifier/Ben.Demystifier.csproj
+++ b/src/Ben.Demystifier/Ben.Demystifier.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net45;net6</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <PackageIcon>icon.png</PackageIcon>

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -605,7 +605,7 @@ namespace System.Diagnostics
             {
                 var customAttribs = parameter.GetCustomAttributes(inherit: false);
 
-                var tupleNameAttribute = customAttribs.OfType<Attribute>().FirstOrDefault(a => a.IsTupleElementNameAttribue());
+                var tupleNameAttribute = customAttribs.OfType<Attribute>().FirstOrDefault(a => a.IsTupleElementNameAttribute());
 
                 var tupleNames = tupleNameAttribute?.GetTransformerNames();
 

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.Internal
     /// </summary>
     public static class ReflectionHelper
     {
-        private static PropertyInfo? tranformerNamesLazyPropertyInfo;
+        private static PropertyInfo? transformerNamesLazyPropertyInfo;
 
         /// <summary>
         /// Returns true if the <paramref name="type"/> is a value tuple type.
@@ -26,10 +26,10 @@ namespace System.Diagnostics.Internal
         /// Returns true if the given <paramref name="attribute"/> is of type <code>TupleElementNameAttribute</code>.
         /// </summary>
         /// <remarks>
-        /// To avoid compile-time depencency hell with System.ValueTuple, this method uses reflection and not checks statically that 
+        /// To avoid compile-time dependency hell with System.ValueTuple, this method uses reflection and not checks statically that 
         /// the given <paramref name="attribute"/> is <code>TupleElementNameAttribute</code>.
         /// </remarks>
-        public static bool IsTupleElementNameAttribue(this Attribute attribute)
+        public static bool IsTupleElementNameAttribute(this Attribute attribute)
         {
             var attributeType = attribute.GetType();
             return attributeType.Namespace == "System.Runtime.CompilerServices" &&
@@ -40,12 +40,12 @@ namespace System.Diagnostics.Internal
         /// Returns 'TransformNames' property value from a given <paramref name="attribute"/>.
         /// </summary>
         /// <remarks>
-        /// To avoid compile-time depencency hell with System.ValueTuple, this method uses reflection 
+        /// To avoid compile-time dependency hell with System.ValueTuple, this method uses reflection 
         /// instead of casting the attribute to a specific type.
         /// </remarks>
         public static IList<string>? GetTransformerNames(this Attribute attribute)
         {
-            Debug.Assert(attribute.IsTupleElementNameAttribue());
+            Debug.Assert(attribute.IsTupleElementNameAttribute());
 
             var propertyInfo = GetTransformNamesPropertyInfo(attribute.GetType());
             return propertyInfo?.GetValue(attribute) as IList<string>;
@@ -54,9 +54,9 @@ namespace System.Diagnostics.Internal
         private static PropertyInfo? GetTransformNamesPropertyInfo(Type attributeType)
         {
 #pragma warning disable 8634
-            return LazyInitializer.EnsureInitialized(ref tranformerNamesLazyPropertyInfo,
+            return LazyInitializer.EnsureInitialized(ref transformerNamesLazyPropertyInfo,
 #pragma warning restore 8634
-                () => attributeType.GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public));
+                () => attributeType.GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public)!);
         }
     }
 }


### PR DESCRIPTION
In net the the nullability of the LazyInitializer.EnsureInitialized func has been clarified. It can no longer return a null

and fixed some typos