### PR TITLE
only get field value when is delegate

### DIFF
--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -190,11 +190,11 @@ namespace System.Diagnostics
                             {
                                 if (typeof(Delegate).IsAssignableFrom(field.FieldType))
                                 {
-                                    var value = field.GetValue(field);
-                                    if (value is Delegate d && d.Target is not null)
+                                    var value = (Delegate?)field.GetValue(field);
+                                    if (value is {Target: { }})
                                     {
-                                        if (ReferenceEquals(d.Method, originMethod) &&
-                                            d.Target.ToString() == originMethod.DeclaringType?.ToString())
+                                        if (ReferenceEquals(value.Method, originMethod) &&
+                                            value.Target.ToString() == originMethod.DeclaringType?.ToString())
                                         {
                                             methodDisplayInfo.Name = field.Name;
                                             methodDisplayInfo.IsLambda = false;

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -188,16 +188,19 @@ namespace System.Diagnostics
                             var fields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
                             foreach (var field in fields)
                             {
-                                var value = field.GetValue(field);
-                                if (value is Delegate d && d.Target is not null)
+                                if (typeof(Delegate).IsAssignableFrom(field.FieldType))
                                 {
-                                    if (ReferenceEquals(d.Method, originMethod) &&
-                                        d.Target.ToString() == originMethod.DeclaringType?.ToString())
+                                    var value = field.GetValue(field);
+                                    if (value is Delegate d && d.Target is not null)
                                     {
-                                        methodDisplayInfo.Name = field.Name;
-                                        methodDisplayInfo.IsLambda = false;
-                                        method = originMethod;
-                                        break;
+                                        if (ReferenceEquals(d.Method, originMethod) &&
+                                            d.Target.ToString() == originMethod.DeclaringType?.ToString())
+                                        {
+                                            methodDisplayInfo.Name = field.Name;
+                                            methodDisplayInfo.IsLambda = false;
+                                            method = originMethod;
+                                            break;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
 * slight perf improvement. avoid a field getvalue when types dont match and dont unnecessarily trigger a static constructor
 * reduces the chance of an exception in a  static constructor from bubbling up

found in sentry: [Exception Thrown in a Static Constructor Is Not Being Sent To Sentry](https://github.com/getsentry/sentry-dotnet/issues/1379)

@benaadams given a static constructor (triggered by the getfield) could still throw, do you think the get field logic should be wrapped in a try? i would assume a slightly less accurate display name i better than an exception?