### PR TITLE
Improve native AOT compatibility

### DIFF
--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -12,7 +12,9 @@ namespace System.Diagnostics.Internal
     /// </summary>
     public static class ReflectionHelper
     {
+#if NET45
         private static PropertyInfo? transformerNamesLazyPropertyInfo;
+#endif
 
         /// <summary>
         /// Returns true if the <paramref name="type"/> is a value tuple type.
@@ -22,6 +24,7 @@ namespace System.Diagnostics.Internal
             return type.Namespace == "System" && type.Name.Contains("ValueTuple`");
         }
 
+#if NET45
         /// <summary>
         /// Returns true if the given <paramref name="attribute"/> is of type <code>TupleElementNameAttribute</code>.
         /// </summary>
@@ -43,12 +46,12 @@ namespace System.Diagnostics.Internal
         /// To avoid compile-time dependency hell with System.ValueTuple, this method uses reflection 
         /// instead of casting the attribute to a specific type.
         /// </remarks>
-        public static IList<string>? GetTransformerNames(this Attribute attribute)
+        public static IList<string?>? GetTransformerNames(this Attribute attribute)
         {
             Debug.Assert(attribute.IsTupleElementNameAttribute());
 
             var propertyInfo = GetTransformNamesPropertyInfo(attribute.GetType());
-            return propertyInfo?.GetValue(attribute) as IList<string>;
+            return propertyInfo?.GetValue(attribute) as IList<string?>;
         }
 
         private static PropertyInfo? GetTransformNamesPropertyInfo(Type attributeType)
@@ -58,5 +61,6 @@ namespace System.Diagnostics.Internal
 #pragma warning restore 8634
                 () => attributeType.GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public)!);
         }
+#endif
     }
 }

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -9,9 +9,9 @@ namespace System.Diagnostics
 {
     public class ValueTupleResolvedParameter : ResolvedParameter
     {
-        public IList<string> TupleNames { get; }
+        public IList<string?> TupleNames { get; }
 
-        public ValueTupleResolvedParameter(Type resolvedType, IList<string> tupleNames) 
+        public ValueTupleResolvedParameter(Type resolvedType, IList<string?> tupleNames) 
             : base(resolvedType) 
             => TupleNames = tupleNames;
 


### PR DESCRIPTION
In the end, someone will need to do the work to enable the AOT/trim/single file safety analyzers and [address all the warnings](https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/), but this is enough to have a golden path that makes `sample/StackTrace` project produce the same results under native AOT as under JIT.

Necessary fixes:

* `GetMethodBody` under AOT throws. This will not return anything useful under Mono with ILStrip either. The code simply needs to deal with it.
* Runtime reflection stack doesn't guarantee referential equality of `MemberInfo`s (except for `TypeInfo`). This is also true on JIT-based runtimes, but there's even less caching on native AOT. Use operator `==`.
* The reflection to read `TupleElementNamesAttribute` is trim-unfriendly and cannot be analyzed. Replace with no-reflection.
* Some fallout from the previous point because the nullable annotations on the thing returned by reflection were wrong.