### PR TITLE
Make trim warnings more specific

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-18.04, macOS-latest]
+        os: [windows-latest, ubuntu-latest, macOS-latest]
         config: [Debug, Release]
     steps:
       - name: Clone source

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,26 +18,26 @@ jobs:
         config: [Debug, Release]
     steps:
       - name: Clone source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDK (v2.1)
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '2.1.818'
       - name: Setup .NET SDK (v3.1)
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '3.1.414'
       - name: Setup .NET SDK (v5.0)
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.402'
       - name: Setup .NET SDK (v6.0)
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.100-rc.2.21505.57'
+          dotnet-version: '6.0.417'
 
       - name: Get .NET information
         run: dotnet --info

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />

--- a/sample/StackTrace/StackTrace.csproj
+++ b/sample/StackTrace/StackTrace.csproj
@@ -9,4 +9,8 @@
     <ProjectReference Include="..\..\src\Ben.Demystifier\Ben.Demystifier.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+  </ItemGroup>
+
 </Project>

--- a/src/Ben.Demystifier/Constants.cs
+++ b/src/Ben.Demystifier/Constants.cs
@@ -1,0 +1,7 @@
+namespace Ben.Demystifier;
+
+internal static class Constants
+{
+    internal const string TrimWarning = "This class should be avoided when compiling for AOT.";
+    internal const string SuppressionResurfaced = "Surfaced by parent class";
+}

--- a/src/Ben.Demystifier/Constants.cs
+++ b/src/Ben.Demystifier/Constants.cs
@@ -4,4 +4,6 @@ internal static class Constants
 {
     internal const string TrimWarning = "This class should be avoided when compiling for AOT.";
     internal const string SuppressionResurfaced = "Surfaced by parent class";
+    internal const string AvoidAtRuntime = "Non-trimmable code is avoided at runtime";
+    internal const string SingleFileFallback = "Fallback functionality for single files";
 }

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace System.Diagnostics
 {
-    public class EnhancedStackFrame : StackFrame
+    internal class EnhancedStackFrame : StackFrame
     {
         private readonly string? _fileName;
         private readonly int _lineNumber;

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public class EnhancedStackFrame : StackFrame
+    internal class EnhancedStackFrame : StackFrame
     {
         private readonly string? _fileName;
         private readonly int _lineNumber;

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class EnhancedStackFrame : StackFrame
     {
         private readonly string? _fileName;

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace System.Diagnostics
 {
-    internal class EnhancedStackFrame : StackFrame
+    public class EnhancedStackFrame : StackFrame
     {
         private readonly string? _fileName;
         private readonly int _lineNumber;

--- a/src/Ben.Demystifier/EnhancedStackFrame.cs
+++ b/src/Ben.Demystifier/EnhancedStackFrame.cs
@@ -1,10 +1,15 @@
 ﻿// Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     internal class EnhancedStackFrame : StackFrame
     {
         private readonly string? _fileName;

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -6,6 +6,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Internal;
 using System.Linq;
 using System.Reflection;
@@ -14,9 +15,13 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public partial class EnhancedStackTrace
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal partial class EnhancedStackTrace
+    public partial class EnhancedStackTrace
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
         private static readonly Type? AsyncIteratorStateMachineAttributeType = Type.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public partial class EnhancedStackTrace
+    internal partial class EnhancedStackTrace
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
         private static readonly Type? AsyncIteratorStateMachineAttributeType = Type.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);

--- a/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.Frames.cs
@@ -19,14 +19,12 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
     internal partial class EnhancedStackTrace
     {
         private static readonly Type? StackTraceHiddenAttributeType = Type.GetType("System.Diagnostics.StackTraceHiddenAttribute", false);
         private static readonly Type? AsyncIteratorStateMachineAttributeType = Type.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026: RequiresUnreferencedCode", Justification = Constants.AvoidAtRuntime)]
         static EnhancedStackTrace()
         {
             if (AsyncIteratorStateMachineAttributeType != null) return;
@@ -35,15 +33,18 @@ namespace System.Diagnostics
             try
             {
                 mba = Assembly.Load("Microsoft.Bcl.AsyncInterfaces");
+                AsyncIteratorStateMachineAttributeType = mba.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);
             }
             catch
             {
                 return;
             }
 
-            AsyncIteratorStateMachineAttributeType = mba.GetType("System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute", false);
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static List<EnhancedStackFrame> GetFrames(Exception exception)
         {
             if (exception == null)
@@ -57,6 +58,9 @@ namespace System.Diagnostics
             return GetFrames(stackTrace);
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static List<EnhancedStackFrame> GetFrames(StackTrace stackTrace)
         {
             var frames = new List<EnhancedStackFrame>();
@@ -124,6 +128,9 @@ namespace System.Diagnostics
             return frames;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static ResolvedMethod GetMethodDisplayString(MethodBase originMethod)
         {
             var method = originMethod;
@@ -300,6 +307,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static bool TryResolveGeneratedName(ref MethodBase method, out Type? type, out string methodName, out string? subMethodName, out GeneratedNameKind kind, out int? ordinal)
         {
             kind = GeneratedNameKind.None;
@@ -386,6 +396,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static bool TryResolveSourceMethod(IEnumerable<MethodBase> candidateMethods, GeneratedNameKind kind, string? matchHint, ref MethodBase method, ref Type? type, out int? ordinal)
         {
             ordinal = null;
@@ -455,6 +468,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static void GetOrdinal(MethodBase method, ref int? ordinal)
         {
             var lamdaStart = method.Name.IndexOf((char)GeneratedNameKind.LambdaMethod + "__") + 3;
@@ -610,6 +626,9 @@ namespace System.Diagnostics
             return string.Empty;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static ResolvedParameter GetParameter(ParameterInfo parameter)
         {
             var prefix = GetPrefix(parameter);
@@ -648,6 +667,9 @@ namespace System.Diagnostics
             };
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         private static ResolvedParameter GetValueTupleParameter(IList<string?> tupleNames, string prefix, string? name, Type parameterType)
         {
             return new ValueTupleResolvedParameter(parameterType, tupleNames)
@@ -867,6 +889,9 @@ namespace System.Diagnostics
             return false;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         // https://github.com/dotnet/runtime/blob/c985bdcec2a9190e733bcada413a193d5ff60c0d/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs#L375-L430
         private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
         {

--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace System.Diagnostics
 {
-    public partial class EnhancedStackTrace : StackTrace, IEnumerable<EnhancedStackFrame>
+    internal partial class EnhancedStackTrace : StackTrace, IEnumerable<EnhancedStackFrame>
     {
         public static EnhancedStackTrace Current() => new EnhancedStackTrace(new StackTrace(1 /* skip this one frame */, true));
 

--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace System.Diagnostics
 {
-    internal partial class EnhancedStackTrace : StackTrace, IEnumerable<EnhancedStackFrame>
+    public partial class EnhancedStackTrace : StackTrace, IEnumerable<EnhancedStackFrame>
     {
         public static EnhancedStackTrace Current() => new EnhancedStackTrace(new StackTrace(1 /* skip this one frame */, true));
 

--- a/src/Ben.Demystifier/EnhancedStackTrace.cs
+++ b/src/Ben.Demystifier/EnhancedStackTrace.cs
@@ -6,11 +6,15 @@ using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
 using System.IO;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
     internal partial class EnhancedStackTrace : StackTrace, IEnumerable<EnhancedStackFrame>
     {
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static EnhancedStackTrace Current() => new EnhancedStackTrace(new StackTrace(1 /* skip this one frame */, true));
 
         private readonly List<EnhancedStackFrame> _frames;
@@ -26,6 +30,9 @@ namespace System.Diagnostics
         // Exceptions:
         //   T:System.ArgumentNullException:
         //     The parameter e is null.
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public EnhancedStackTrace(Exception e)
         {
             if (e == null)
@@ -36,7 +43,9 @@ namespace System.Diagnostics
             _frames = GetFrames(e);
         }
 
-
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public EnhancedStackTrace(StackTrace stackTrace)
         {
             if (stackTrace == null)

--- a/src/Ben.Demystifier/Enumerable/EnumerableIList.cs
+++ b/src/Ben.Demystifier/Enumerable/EnumerableIList.cs
@@ -3,12 +3,12 @@
 
 namespace System.Collections.Generic.Enumerable
 {
-    public static class EnumerableIList
+    internal static class EnumerableIList
     {
         public static EnumerableIList<T> Create<T>(IList<T> list) => new EnumerableIList<T>(list);
     }
 
-    public struct EnumerableIList<T> : IEnumerableIList<T>, IList<T>
+    internal struct EnumerableIList<T> : IEnumerableIList<T>, IList<T>
     {
         private readonly IList<T> _list;
 

--- a/src/Ben.Demystifier/Enumerable/EnumerableIList.cs
+++ b/src/Ben.Demystifier/Enumerable/EnumerableIList.cs
@@ -3,12 +3,12 @@
 
 namespace System.Collections.Generic.Enumerable
 {
-    internal static class EnumerableIList
+    public static class EnumerableIList
     {
         public static EnumerableIList<T> Create<T>(IList<T> list) => new EnumerableIList<T>(list);
     }
 
-    internal struct EnumerableIList<T> : IEnumerableIList<T>, IList<T>
+    public struct EnumerableIList<T> : IEnumerableIList<T>, IList<T>
     {
         private readonly IList<T> _list;
 

--- a/src/Ben.Demystifier/Enumerable/EnumeratorIList.cs
+++ b/src/Ben.Demystifier/Enumerable/EnumeratorIList.cs
@@ -3,7 +3,7 @@
 
 namespace System.Collections.Generic.Enumerable
 {
-    public struct EnumeratorIList<T> : IEnumerator<T>
+    internal struct EnumeratorIList<T> : IEnumerator<T>
     {
         private readonly IList<T> _list;
         private int _index;

--- a/src/Ben.Demystifier/Enumerable/EnumeratorIList.cs
+++ b/src/Ben.Demystifier/Enumerable/EnumeratorIList.cs
@@ -3,7 +3,7 @@
 
 namespace System.Collections.Generic.Enumerable
 {
-    internal struct EnumeratorIList<T> : IEnumerator<T>
+    public struct EnumeratorIList<T> : IEnumerator<T>
     {
         private readonly IList<T> _list;
         private int _index;

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Generic;
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
@@ -18,6 +20,9 @@ namespace System.Diagnostics
         /// <summary>
         /// Demystifies the given <paramref name="exception"/> and tracks the original stack traces for the whole exception tree.
         /// </summary>
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = Constants.SuppressionResurfaced)]
+        #endif
         public static T Demystify<T>(this T exception) where T : Exception
         {
             try
@@ -57,6 +62,9 @@ namespace System.Diagnostics
         /// computes a demystified string representation and then restores the original state of the exception back.
         /// </remarks>
         [Contracts.Pure]
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static string ToStringDemystified(this Exception exception) 
             => new StringBuilder().AppendDemystified(exception).ToString();
     }

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -10,6 +10,9 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+    /// <summary>
+    /// Extension methods to Demystify exveption stack traces
+    /// </summary>
     public static class ExceptionExtensions
     {
         private static readonly FieldInfo? stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -10,7 +10,7 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
-    public static class ExceptionExtensions
+    internal static class ExceptionExtensions
     {
         private static readonly FieldInfo? stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -10,7 +10,7 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
-    internal static class ExceptionExtensions
+    public static class ExceptionExtensions
     {
         private static readonly FieldInfo? stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics
     /// <summary>
     /// Extension methods to Demystify exveption stack traces
     /// </summary>
-    public static class ExceptionExtensions
+    internal static class ExceptionExtensions
     {
         private static readonly FieldInfo? stackTraceString = typeof(Exception).GetField("_stackTraceString", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/src/Ben.Demystifier/ExceptionExtensions.cs
+++ b/src/Ben.Demystifier/ExceptionExtensions.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic.Enumerable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
-using Ben.Demystifier;
+using Constants = Ben.Demystifier.Constants;
 
 namespace System.Diagnostics
 {
@@ -23,9 +23,9 @@ namespace System.Diagnostics
         /// <summary>
         /// Demystifies the given <paramref name="exception"/> and tracks the original stack traces for the whole exception tree.
         /// </summary>
-        #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public static T Demystify<T>(this T exception) where T : Exception
         {
             try

--- a/src/Ben.Demystifier/Internal/ILReader.cs
+++ b/src/Ben.Demystifier/Internal/ILReader.cs
@@ -1,8 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Emit;
+using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     internal class ILReader
     {
         private static OpCode[] singleByteOpCode;

--- a/src/Ben.Demystifier/Internal/ILReader.cs
+++ b/src/Ben.Demystifier/Internal/ILReader.cs
@@ -5,9 +5,6 @@ using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
     internal class ILReader
     {
         private static OpCode[] singleByteOpCode;
@@ -16,13 +13,15 @@ namespace System.Diagnostics.Internal
         private readonly byte[] _cil;
         private int ptr;
 
-
         public ILReader(byte[] cil) => _cil = cil;
 
         public OpCode OpCode { get; private set; }
         public int MetadataToken { get; private set; }
         public MemberInfo? Operand { get; private set; }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         public bool Read(MethodBase methodInfo)
         {
             if (ptr < _cil.Length)
@@ -43,6 +42,9 @@ namespace System.Diagnostics.Internal
                 return doubleByteOpCode[ReadByte()];
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
         MemberInfo? ReadOperand(OpCode code, MethodBase methodInfo)
         {
             MetadataToken = 0;

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -2,20 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/PortablePdbReader.cs
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     internal class PortablePdbReader : IDisposable
     {
         private readonly Dictionary<string, MetadataReaderProvider> _cache =
             new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
 
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = Constants.SuppressionResurfaced)]
+        #endif
         public void PopulateStackFrame(StackFrame frameInfo, MethodBase method, int IlOffset, out string fileName, out int row, out int column)
         {
             fileName = "";

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -21,9 +21,9 @@ namespace System.Diagnostics.Internal
         private readonly Dictionary<string, MetadataReaderProvider> _cache =
             new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
 
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#endif
         public void PopulateStackFrame(StackFrame frameInfo, MethodBase method, int IlOffset, out string fileName, out int row, out int column)
         {
             fileName = "";

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -78,18 +78,20 @@ namespace System.Diagnostics.Internal
 
         private MetadataReader? GetMetadataReader(string assemblyPath)
         {
-            if (!_cache.TryGetValue(assemblyPath, out var provider) && provider is not null)
+            if (_cache.TryGetValue(assemblyPath, out var provider))
             {
-                var pdbPath = GetPdbPath(assemblyPath);
-
-                if (!string.IsNullOrEmpty(pdbPath) && File.Exists(pdbPath) && IsPortable(pdbPath!))
-                {
-                    var pdbStream = File.OpenRead(pdbPath);
-                    provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
-                }
-
-                _cache[assemblyPath] = provider;
+                return provider?.GetMetadataReader();
             }
+
+            var pdbPath = GetPdbPath(assemblyPath);
+
+            if (!string.IsNullOrEmpty(pdbPath) && File.Exists(pdbPath) && IsPortable(pdbPath!))
+            {
+                var pdbStream = File.OpenRead(pdbPath);
+                provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+            }
+
+            _cache[assemblyPath] = provider!;
 
             return provider?.GetMetadataReader();
         }

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -43,6 +43,7 @@ namespace System.Diagnostics.Internal
             }
 
             var methodToken = MetadataTokens.Handle(method.MetadataToken);
+            // Sometimes we get a HandleKind.ModuleDefinition. We simply don't populate those stack frames.
             if (methodToken.Kind != HandleKind.MethodDefinition)
             {
                 return;

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -15,7 +15,9 @@ namespace System.Diagnostics.Internal
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.StackTrace.Sources/StackFrame/PortablePdbReader.cs
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
+#endif 
+    // Allow direct file system usage
+#pragma warning disable SN0001
     internal class PortablePdbReader : IDisposable
     {
         private readonly Dictionary<string, MetadataReaderProvider> _cache =
@@ -145,4 +147,5 @@ namespace System.Diagnostics.Internal
             _cache.Clear();
         }
     }
+#pragma warning restore SN0001
 }

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics.Internal
             new Dictionary<string, MetadataReaderProvider>(StringComparer.Ordinal);
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path", Justification = Constants.SingleFileFallback)]
 #endif
         public void PopulateStackFrame(StackFrame frameInfo, MethodBase method, int IlOffset, out string fileName, out int row, out int column)
         {

--- a/src/Ben.Demystifier/Internal/PortablePdbReader.cs
+++ b/src/Ben.Demystifier/Internal/PortablePdbReader.cs
@@ -43,9 +43,10 @@ namespace System.Diagnostics.Internal
             }
 
             var methodToken = MetadataTokens.Handle(method.MetadataToken);
-
-            Debug.Assert(methodToken.Kind == HandleKind.MethodDefinition);
-
+            if (methodToken.Kind != HandleKind.MethodDefinition)
+            {
+                return;
+            }
             var handle = ((MethodDefinitionHandle)methodToken).ToDebugInformationHandle();
 
             if (!handle.IsNil)

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.Internal
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal static class ReflectionHelper
+    public static class ReflectionHelper
     {
         private static PropertyInfo? transformerNamesLazyPropertyInfo;
 

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -2,14 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
+using Ben.Demystifier;
 
 namespace System.Diagnostics.Internal
 {
     /// <summary>
     /// A helper class that contains utilities methods for dealing with reflection.
     /// </summary>
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public static class ReflectionHelper
     {
         private static PropertyInfo? transformerNamesLazyPropertyInfo;

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics.Internal
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public static class ReflectionHelper
+    internal static class ReflectionHelper
     {
         private static PropertyInfo? transformerNamesLazyPropertyInfo;
 

--- a/src/Ben.Demystifier/Internal/ReflectionHelper.cs
+++ b/src/Ben.Demystifier/Internal/ReflectionHelper.cs
@@ -17,7 +17,9 @@ namespace System.Diagnostics.Internal
 #endif
     internal static class ReflectionHelper
     {
+#if NET45
         private static PropertyInfo? transformerNamesLazyPropertyInfo;
+#endif
 
         /// <summary>
         /// Returns true if the <paramref name="type"/> is a value tuple type.
@@ -27,6 +29,7 @@ namespace System.Diagnostics.Internal
             return type.Namespace == "System" && type.Name.Contains("ValueTuple`");
         }
 
+#if NET45
         /// <summary>
         /// Returns true if the given <paramref name="attribute"/> is of type <code>TupleElementNameAttribute</code>.
         /// </summary>
@@ -48,12 +51,12 @@ namespace System.Diagnostics.Internal
         /// To avoid compile-time dependency hell with System.ValueTuple, this method uses reflection 
         /// instead of casting the attribute to a specific type.
         /// </remarks>
-        public static IList<string>? GetTransformerNames(this Attribute attribute)
+        public static IList<string?>? GetTransformerNames(this Attribute attribute)
         {
             Debug.Assert(attribute.IsTupleElementNameAttribute());
 
             var propertyInfo = GetTransformNamesPropertyInfo(attribute.GetType());
-            return propertyInfo?.GetValue(attribute) as IList<string>;
+            return propertyInfo?.GetValue(attribute) as IList<string?>;
         }
 
         private static PropertyInfo? GetTransformNamesPropertyInfo(Type attributeType)
@@ -63,5 +66,6 @@ namespace System.Diagnostics.Internal
 #pragma warning restore 8634
                 () => attributeType.GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public)!);
         }
+#endif
     }
 }

--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class ResolvedMethod
     {
         public MethodBase? MethodBase { get; set; }

--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal class ResolvedMethod
+    public class ResolvedMethod
     {
         public MethodBase? MethodBase { get; set; }
 

--- a/src/Ben.Demystifier/ResolvedMethod.cs
+++ b/src/Ben.Demystifier/ResolvedMethod.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public class ResolvedMethod
+    internal class ResolvedMethod
     {
         public MethodBase? MethodBase { get; set; }
 

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -1,10 +1,18 @@
 // Copyright (c) Ben A Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
+
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class ResolvedParameter
     {
         public string? Name { get; set; }
@@ -18,6 +26,9 @@ namespace System.Diagnostics
 
         public override string ToString() => Append(new StringBuilder()).ToString();
 
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+#endif
         public StringBuilder Append(StringBuilder sb)
         {
             if (ResolvedType.Assembly.ManifestModule.Name == "FSharp.Core.dll" && ResolvedType.Name == "Unit")

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public class ResolvedParameter
+    internal class ResolvedParameter
     {
         public string? Name { get; set; }
 

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal class ResolvedParameter
+    public class ResolvedParameter
     {
         public string? Name { get; set; }
 

--- a/src/Ben.Demystifier/ResolvedParameter.cs
+++ b/src/Ben.Demystifier/ResolvedParameter.cs
@@ -27,13 +27,13 @@ namespace System.Diagnostics
         public override string ToString() => Append(new StringBuilder()).ToString();
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3002: calling members marked with 'RequiresAssemblyFilesAttribute'", Justification = Constants.SingleFileFallback)]
 #endif
         public StringBuilder Append(StringBuilder sb)
         {
             if (ResolvedType.Assembly.ManifestModule.Name == "FSharp.Core.dll" && ResolvedType.Name == "Unit")
                 return sb;
-            
+
             if (!string.IsNullOrEmpty(Prefix))
             {
                 sb.Append(Prefix)
@@ -62,7 +62,7 @@ namespace System.Diagnostics
             return sb;
         }
 
-        protected virtual void AppendTypeName(StringBuilder sb) 
+        protected virtual void AppendTypeName(StringBuilder sb)
         {
             sb.AppendTypeDisplayName(ResolvedType, fullName: false, includeGenericParameterNames: true);
         }

--- a/src/Ben.Demystifier/StringBuilderExtentions.cs
+++ b/src/Ben.Demystifier/StringBuilderExtentions.cs
@@ -2,10 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic.Enumerable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics 
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public static class StringBuilderExtentions
     {
         public static StringBuilder AppendDemystified(this StringBuilder builder, Exception exception)

--- a/src/Ben.Demystifier/StringBuilderExtentions.cs
+++ b/src/Ben.Demystifier/StringBuilderExtentions.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public static class StringBuilderExtentions
+    internal static class StringBuilderExtentions
     {
         public static StringBuilder AppendDemystified(this StringBuilder builder, Exception exception)
         {

--- a/src/Ben.Demystifier/StringBuilderExtentions.cs
+++ b/src/Ben.Demystifier/StringBuilderExtentions.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal static class StringBuilderExtentions
+    public static class StringBuilderExtentions
     {
         public static StringBuilder AppendDemystified(this StringBuilder builder, Exception exception)
         {

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics
 {
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public static class TypeNameHelper
     {
         public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
@@ -73,6 +78,9 @@ namespace System.Diagnostics
             return (genericPartIndex >= 0) ? type.Name.Substring(0, genericPartIndex) : type.Name;
         }
 
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        #endif
         private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
             if (type.IsGenericType)
@@ -145,6 +153,9 @@ namespace System.Diagnostics
             }
         }
 
+        #if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        #endif
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {
             var offset = 0;

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -78,9 +78,9 @@ namespace System.Diagnostics
             return (genericPartIndex >= 0) ? type.Name.Substring(0, genericPartIndex) : type.Name;
         }
 
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#endif
         private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
             if (type.IsGenericType)
@@ -153,9 +153,9 @@ namespace System.Diagnostics
             }
         }
 
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
-        #endif
+#endif
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {
             var offset = 0;

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal static class TypeNameHelper
+    public static class TypeNameHelper
     {
         public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
         {

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public static class TypeNameHelper
+    internal static class TypeNameHelper
     {
         public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
         {

--- a/src/Ben.Demystifier/TypeNameHelper.cs
+++ b/src/Ben.Demystifier/TypeNameHelper.cs
@@ -9,9 +9,6 @@ using Ben.Demystifier;
 namespace System.Diagnostics
 {
     // Adapted from https://github.com/aspnet/Common/blob/dev/shared/Microsoft.Extensions.TypeNameHelper.Sources/TypeNameHelper.cs
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode(Constants.TrimWarning)]
-#endif
     internal static class TypeNameHelper
     {
         public static readonly Dictionary<Type, string> BuiltInTypeNames = new Dictionary<Type, string>
@@ -79,7 +76,7 @@ namespace System.Diagnostics
         }
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3002: calling members marked with 'RequiresAssemblyFilesAttribute'", Justification = Constants.SingleFileFallback)]
 #endif
         private static void ProcessType(StringBuilder builder, Type type, DisplayNameOptions options)
         {
@@ -154,7 +151,7 @@ namespace System.Diagnostics
         }
 
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = Constants.SuppressionResurfaced)]
+        [UnconditionalSuppressMessage("SingleFile", "IL3002: calling members marked with 'RequiresAssemblyFilesAttribute'", Justification = Constants.SingleFileFallback)]
 #endif
         private static void ProcessGenericType(StringBuilder builder, Type type, Type[] genericArguments, int length, DisplayNameOptions options)
         {

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    internal class ValueTupleResolvedParameter : ResolvedParameter
+    public class ValueTupleResolvedParameter : ResolvedParameter
     {
         public IList<string> TupleNames { get; }
 

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(Constants.TrimWarning)]
 #endif
-    public class ValueTupleResolvedParameter : ResolvedParameter
+    internal class ValueTupleResolvedParameter : ResolvedParameter
     {
         public IList<string> TupleNames { get; }
 

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -2,11 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Internal;
 using System.Text;
+using Ben.Demystifier;
 
 namespace System.Diagnostics 
 {
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(Constants.TrimWarning)]
+#endif
     public class ValueTupleResolvedParameter : ResolvedParameter
     {
         public IList<string> TupleNames { get; }

--- a/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
+++ b/src/Ben.Demystifier/ValueTupleResolvedParameter.cs
@@ -14,9 +14,9 @@ namespace System.Diagnostics
 #endif
     internal class ValueTupleResolvedParameter : ResolvedParameter
     {
-        public IList<string> TupleNames { get; }
+        public IList<string?> TupleNames { get; }
 
-        public ValueTupleResolvedParameter(Type resolvedType, IList<string> tupleNames) 
+        public ValueTupleResolvedParameter(Type resolvedType, IList<string?> tupleNames) 
             : base(resolvedType) 
             => TupleNames = tupleNames;
 

--- a/test/Ben.Demystifier.Benchmarks/Ben.Demystifier.Benchmarks.csproj
+++ b/test/Ben.Demystifier.Benchmarks/Ben.Demystifier.Benchmarks.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
     <ProjectReference Include="..\..\src\Ben.Demystifier\Ben.Demystifier.csproj" />
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>

--- a/test/Ben.Demystifier.Test/Ben.Demystifier.Test.csproj
+++ b/test/Ben.Demystifier.Test/Ben.Demystifier.Test.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/test/Ben.Demystifier.Test/MethodTests.cs
+++ b/test/Ben.Demystifier.Test/MethodTests.cs
@@ -77,11 +77,18 @@ namespace Ben.Demystifier.Test
             stackTrace = LineEndingsHelper.RemoveLineEndings(stackTrace);
             var trace = string.Join(string.Empty, stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
 
+#if (NETFRAMEWORK && !DEBUG)
+            var expected = string.Join(string.Empty,
+                "System.ArgumentException: Value does not fall within the expected range.",
+                "   at void Ben.Demystifier.Test.MethodTests.MethodWithLambda()+() => { }",
+                "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithLambda()");
+#else
             var expected = string.Join(string.Empty,
                 "System.ArgumentException: Value does not fall within the expected range.",
                 "   at void Ben.Demystifier.Test.MethodTests.MethodWithLambda()+() => { }",
                 "   at void Ben.Demystifier.Test.MethodTests.MethodWithLambda()",
                 "   at void Ben.Demystifier.Test.MethodTests.DemistifiesMethodWithLambda()");
+#endif            
 
             Assert.Equal(expected, trace);
         }


### PR DESCRIPTION
Previously the `RequiresUnreferencedCodeAttribute` was often applied to entire classes rather than the specific methods that required unreferenced code... which made it difficult to create runtime workarounds. 